### PR TITLE
fix nginx users passwords path

### DIFF
--- a/rootfs/etc/cont-init.d/20-nginx-users
+++ b/rootfs/etc/cont-init.d/20-nginx-users
@@ -19,5 +19,5 @@ done
 # Users were created - enable authetncaition in the nginx file
 if [ -f /etc/munin/munin-nginx-users ]; then
     echo 'auth_basic "Munin Server";' >> /etc/munin/munin-nginx-auth.conf
-    echo 'auth_basic_user_file "/etc/munin/htpasswd.users";' >> /etc/munin/munin-nginx-auth.conf
+    echo 'auth_basic_user_file "/etc/munin/munin-nginx-users";' >> /etc/munin/munin-nginx-auth.conf
 fi


### PR DESCRIPTION
Hello,

I have tried to use your docker image, but there is misconfiguration in path to users credential file. 

Thank you,
Martin